### PR TITLE
Fix chart dir name typo

### DIFF
--- a/charts/hdfs-namenode-k8s/README.md
+++ b/charts/hdfs-namenode-k8s/README.md
@@ -20,7 +20,7 @@ HDFS `namenode` running inside a kubernetes cluster. See the other chart for
   2. Launch this helm chart, `hdfs-namenode-k8s`.
 
   ```
-  $ helm install -n my-hdfs-namenode --namespace kube-system hdfs-k8s
+  $ helm install -n my-hdfs-namenode --namespace kube-system hdfs-k8s-namenode
   ```
 
   3. Confirm the daemon is launched.


### PR DESCRIPTION
@foxish 

An example in the README.md was using a wrong dir name.