### PR TITLE
Avoid launching datanodes on labeled nodes

### DIFF
--- a/charts/hdfs-datanode-k8s/README.md
+++ b/charts/hdfs-datanode-k8s/README.md
@@ -12,18 +12,24 @@ HDFS `datanodes` running inside a kubernetes cluster. See the other chart for
 
 ### Usage
 
-  1. Optionally, find the domain name of your k8s cluster that becomes part of
+  1. In some setup, the master node may launch a datanode. To prevent this,
+     label the master node with `hdfs-datanode-exclude`.
+  ```
+  $ kubectl label node YOUR-MASTER-NAME hdfs-datanode-exclude=yes
+  ```
+
+  2. Optionally, find the domain name of your k8s cluster that become part of
      pod and service host names. Default is `cluster.local`. See `values.yaml`
      for additional parameters to change. You can add them below in `--set`,
      as comma-separated entries.
 
-  2. Launch this helm chart, `hdfs-datanode-k8s`.
+  3. Launch this helm chart, `hdfs-datanode-k8s`.
 
   ```
   $ helm install -n my-hdfs-datanode hdfs-datanode-k8s
   ```
 
-  3. Confirm the daemons are launched.
+  4. Confirm the daemons are launched.
 
   ```
   $ kubectl get pods | grep hdfs-datanode-

--- a/charts/hdfs-datanode-k8s/templates/datanode-daemonset.yaml
+++ b/charts/hdfs-datanode-k8s/templates/datanode-daemonset.yaml
@@ -24,6 +24,28 @@ spec:
     metadata:
       labels:
         name: hdfs-datanode
+      annotations:
+        # TODO: The following uses annotation to express affinity
+        # because Kubernetes 1.5 supports affinity only in annotation as alpha
+        # feature. In Kubernetes 1.6, this is now beta and supports regular
+        # YAML construct. Switch to the official syntax when we support 1.6.
+        scheduler.alpha.kubernetes.io/affinity: >
+          {
+            "nodeAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                  {
+                    "matchExpressions": [
+                      {
+                        "key": "hdfs-datanode-exclude",
+                        "operator": "DoesNotExist"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
     spec:
       hostNetwork: true
       hostPID: true


### PR DESCRIPTION
Changes the datanode helm chart to exclude labeled cluster nodes, if any, while launching datanodes. In some setup, datanodes get launched even on the master node. One can mark the master node with label `hdfs-datanode-exclude` and avoid launching datanode on the node. One could use this to mark any other cluster nodes that should be excluded for some reason.

Modified README.md to update the instruction.

@foxish @cvpatel