### PR TITLE
Remove unnecessary clusterDomain option

### DIFF
--- a/charts/hdfs-datanode-k8s/README.md
+++ b/charts/hdfs-datanode-k8s/README.md
@@ -18,18 +18,13 @@ HDFS `datanodes` running inside a kubernetes cluster. See the other chart for
   $ kubectl label node YOUR-MASTER-NAME hdfs-datanode-exclude=yes
   ```
 
-  2. Optionally, find the domain name of your k8s cluster that become part of
-     pod and service host names. Default is `cluster.local`. See `values.yaml`
-     for additional parameters to change. You can add them below in `--set`,
-     as comma-separated entries.
-
-  3. Launch this helm chart, `hdfs-datanode-k8s`.
+  2. Launch this helm chart, `hdfs-datanode-k8s`.
 
   ```
   $ helm install -n my-hdfs-datanode hdfs-datanode-k8s
   ```
 
-  4. Confirm the daemons are launched.
+  3. Confirm the daemons are launched.
 
   ```
   $ kubectl get pods | grep hdfs-datanode-

--- a/charts/hdfs-datanode-k8s/templates/datanode-daemonset.yaml
+++ b/charts/hdfs-datanode-k8s/templates/datanode-daemonset.yaml
@@ -70,7 +70,7 @@ spec:
             # This works only with /etc/resolv.conf mounted from the config map.
             # K8s version 1.6 will fix this, per https://github.com/kubernetes/kubernetes/pull/29378.
             - name: CORE_CONF_fs_defaultFS
-              value: hdfs://hdfs-namenode-0.hdfs-namenode.default.svc.{{ .Values.clusterDomain }}:8020
+              value: hdfs://hdfs-namenode-0.hdfs-namenode.default.svc.cluster.local:8020
           livenessProbe:
             initialDelaySeconds: 30
             httpGet:

--- a/charts/hdfs-datanode-k8s/values.yaml
+++ b/charts/hdfs-datanode-k8s/values.yaml
@@ -15,10 +15,6 @@
 
 # Default values for template variables.
 
-# Set this to the domain name of your cluster that become part of POD and service
-# host names.
-clusterDomain: cluster.local
-
 # A list of the local disk directories on cluster nodes that will contain the datanode
 # blocks. These paths will be mounted to the datanode as K8s HostPath volumes.
 # In a command line, the list should be enclosed in '{' and '}'.

--- a/charts/hdfs-resolv-conf/templates/resolve-conf-configmap.yaml
+++ b/charts/hdfs-resolv-conf/templates/resolve-conf-configmap.yaml
@@ -22,6 +22,6 @@ metadata:
   name: hdfs-resolv-conf
 data:
   resolv.conf: |
-    search default.svc.{{ .Values.clusterDomain }} svc.{{ .Values.clusterDomain }} {{ .Values.clusterDomain }} {{ .Values.hostNetworkDomains }}
+    search default.svc.cluster.local svc.cluster.local cluster.local {{ .Values.hostNetworkDomains }}
     nameserver {{ .Values.clusterDnsIP }}
     options ndots:5

--- a/charts/hdfs-resolv-conf/values.yaml
+++ b/charts/hdfs-resolv-conf/values.yaml
@@ -25,7 +25,3 @@ clusterDnsIP: 10.96.0.10
 # If there are multiple names, then put them inside the quote separted by
 # spaces.
 hostNetworkDomains: ""
-
-# Set this to the domain name of your cluster that becomes part of POD and service
-# host names.
-clusterDomain: cluster.local


### PR DESCRIPTION
@cvpatel @foxish 

The default value `cluster.local` seems to be the value used by many different deployments we played with GKE, EC2 and on-premise. So simplifying.