### PR TITLE
Pass env config variables to hadoop if needed

### DIFF
--- a/charts/hdfs-datanode-k8s/templates/datanode-daemonset.yaml
+++ b/charts/hdfs-datanode-k8s/templates/datanode-daemonset.yaml
@@ -71,8 +71,8 @@ spec:
             # K8s version 1.6 will fix this, per https://github.com/kubernetes/kubernetes/pull/29378.
             - name: CORE_CONF_fs_defaultFS
               value: hdfs://hdfs-namenode-0.hdfs-namenode.default.svc.cluster.local:8020
-            # Custom hadoop_env config
-            {{- range $key, $value := .Values.hadoop_env }}
+            # We now add custom hadoop configuration provided
+            {{- range $key, $value := .Values.customHadoopConfig }}
             {{- if and (ne $key "HDFS_CONF_dfs_datanode_data_dir") (ne $key "CORE_CONF_fs_defaultFS") }}
             - name: {{ $key | quote }}
               value: {{ $value | quote }}

--- a/charts/hdfs-datanode-k8s/templates/datanode-daemonset.yaml
+++ b/charts/hdfs-datanode-k8s/templates/datanode-daemonset.yaml
@@ -71,6 +71,13 @@ spec:
             # K8s version 1.6 will fix this, per https://github.com/kubernetes/kubernetes/pull/29378.
             - name: CORE_CONF_fs_defaultFS
               value: hdfs://hdfs-namenode-0.hdfs-namenode.default.svc.cluster.local:8020
+            # Custom hadoop_env config
+            {{- range $key, $value := .Values.hadoop_env }}
+            {{- if and (ne $key "HDFS_CONF_dfs_datanode_data_dir") (ne $key "CORE_CONF_fs_defaultFS") }}
+            - name: {{ $key | quote }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
           livenessProbe:
             initialDelaySeconds: 30
             httpGet:

--- a/charts/hdfs-datanode-k8s/values.yaml
+++ b/charts/hdfs-datanode-k8s/values.yaml
@@ -21,3 +21,11 @@
 # e.g. --set "dataNodeHostPath={/hdfs-data,/hdfs-data1}"
 dataNodeHostPath:
   - /hdfs-data
+
+# Custom hadoop configuration passed through env variables to hadoop uhopper images.
+# See https://hub.docker.com/r/uhopper/hadoop/ to get more details
+# HDFS_CONF_dfs_datanode_data_dir and CORE_CONF_fs_defaultFS need special handling and
+# they're already set by the chart so any value coming from below config will be ignored
+hadoop_env: {}
+  # Set variables through a hash where env variable is the key, e.g.
+  # HDFS_CONF_dfs_datanode_use_datanode_hostname: "false"

--- a/charts/hdfs-datanode-k8s/values.yaml
+++ b/charts/hdfs-datanode-k8s/values.yaml
@@ -22,10 +22,12 @@
 dataNodeHostPath:
   - /hdfs-data
 
-# Custom hadoop configuration passed through env variables to hadoop uhopper images.
+# Custom hadoop config keys passed through env variables to hadoop uhopper images.
 # See https://hub.docker.com/r/uhopper/hadoop/ to get more details
+# Please note that these are not hadoop env variables, but docker env variables that
+# will be transformed into hadoop config keys
 # HDFS_CONF_dfs_datanode_data_dir and CORE_CONF_fs_defaultFS need special handling and
 # they're already set by the chart so any value coming from below config will be ignored
-hadoop_env: {}
+customHadoopConfig: {}
   # Set variables through a hash where env variable is the key, e.g.
   # HDFS_CONF_dfs_datanode_use_datanode_hostname: "false"

--- a/charts/hdfs-namenode-k8s/templates/namenode-statefulset.yaml
+++ b/charts/hdfs-namenode-k8s/templates/namenode-statefulset.yaml
@@ -52,6 +52,13 @@ spec:
           env:
             - name: CLUSTER_NAME
               value: hdfs-k8s
+            # Custom hadoop_env config
+            {{- range $key, $value := .Values.hadoop_env }}
+            {{- if ne $key "CLUSTER_NAME" }}
+            - name: {{ $key | quote }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
           ports:
           - containerPort: 8020
             name: fs

--- a/charts/hdfs-namenode-k8s/templates/namenode-statefulset.yaml
+++ b/charts/hdfs-namenode-k8s/templates/namenode-statefulset.yaml
@@ -52,8 +52,8 @@ spec:
           env:
             - name: CLUSTER_NAME
               value: hdfs-k8s
-            # Custom hadoop_env config
-            {{- range $key, $value := .Values.hadoop_env }}
+            # We now add custom hadoop configuration provided
+            {{- range $key, $value := .Values.customHadoopConfig }}
             {{- if ne $key "CLUSTER_NAME" }}
             - name: {{ $key | quote }}
               value: {{ $value | quote }}

--- a/charts/hdfs-namenode-k8s/values.yaml
+++ b/charts/hdfs-namenode-k8s/values.yaml
@@ -20,10 +20,12 @@
 # volume.
 nameNodeHostPath: /hdfs-name
 
-# Custom hadoop configuration passed through env variables to hadoop uhopper images.
+# Custom hadoop config keys passed through env variables to hadoop uhopper images.
 # See https://hub.docker.com/r/uhopper/hadoop/ to get more details
+# Please note that these are not hadoop env variables, but docker env variables that
+# will be transformed into hadoop config keys
 # CLUSTER_NAME is already set by the chart so any value coming from below config
 # will be ignored
-hadoop_env: {}
+customHadoopConfig: {}
   # Set variables through a hash where env variable is the key, e.g.
   # HDFS_CONF_dfs_datanode_use_datanode_hostname: "false"

--- a/charts/hdfs-namenode-k8s/values.yaml
+++ b/charts/hdfs-namenode-k8s/values.yaml
@@ -19,3 +19,11 @@
 # fsimage and edit logs. This will be mounted to the namenode as a k8s HostPath
 # volume.
 nameNodeHostPath: /hdfs-name
+
+# Custom hadoop configuration passed through env variables to hadoop uhopper images.
+# See https://hub.docker.com/r/uhopper/hadoop/ to get more details
+# CLUSTER_NAME is already set by the chart so any value coming from below config
+# will be ignored
+hadoop_env: {}
+  # Set variables through a hash where env variable is the key, e.g.
+  # HDFS_CONF_dfs_datanode_use_datanode_hostname: "false"


### PR DESCRIPTION
This fixes #14 

I've decided to explicitly ignore those env variables already set by the chart because they're passed as an array of hashes in the yaml file and I think it is not safe to depend on how env variables are assigned and passed to the container from it.

Datanode chart `if` is not extremely pretty but unless more variables are added before the custom `hadoop_env` config block it should be fine as it is.