### PR TITLE
ClusterFirstWithHostNet to replace resolv.conf override

### DIFF
--- a/charts/hdfs-datanode-k8s/templates/datanode-daemonset.yaml
+++ b/charts/hdfs-datanode-k8s/templates/datanode-daemonset.yaml
@@ -49,6 +49,7 @@ spec:
     spec:
       hostNetwork: true
       hostPID: true
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: datanode
           image: uhopper/hadoop-datanode:2.7.2
@@ -84,11 +85,6 @@ spec:
             - name: hdfs-data-{{ $index }}
               mountPath: /hadoop/dfs/data/{{ $index }}
             {{- end }}
-            # Use subPath below to mount only a single file.
-            # See https://github.com/dshulyak/kubernetes.github.io/commit/d58ba7b075bb4848349a2c920caaa08ff3773d70
-            - name: resolv-conf-volume
-              mountPath: /etc/resolv.conf
-              subPath: resolv.conf
       restartPolicy: Always
       volumes:
         {{- range $index, $path := .Values.dataNodeHostPath }}
@@ -96,9 +92,3 @@ spec:
           hostPath:
             path: {{ $path }}
         {{- end }}
-        - configMap:
-            name: hdfs-resolv-conf
-            items:
-            - key: resolv.conf
-              path: resolv.conf
-          name: resolv-conf-volume

--- a/charts/hdfs-namenode-k8s/templates/namenode-statefulset.yaml
+++ b/charts/hdfs-namenode-k8s/templates/namenode-statefulset.yaml
@@ -46,6 +46,7 @@ spec:
       # like weave. Otherwise, namenode fails to see physical IP address of datanodes.
       hostNetwork: true
       hostPID: true
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: hdfs-namenode
           image: uhopper/hadoop-namenode:2.7.2
@@ -58,11 +59,6 @@ spec:
           volumeMounts:
             - name: hdfs-name
               mountPath: /hadoop/dfs/name
-            # Use subPath below to mount only a single file.
-            # See https://github.com/dshulyak/kubernetes.github.io/commit/d58ba7b075bb4848349a2c920caaa08ff3773d70
-            - name: resolv-conf-volume
-              mountPath: /etc/resolv.conf
-              subPath: resolv.conf
       # Pin the pod to a node. You can label your node like below:
       #   $ kubectl label nodes YOUR-NODE hdfs-namenode-selector=hdfs-namenode-0
       nodeSelector:
@@ -72,9 +68,3 @@ spec:
         - name: hdfs-name
           hostPath:
             path: {{ .Values.nameNodeHostPath }}
-        - configMap:
-            name: hdfs-resolv-conf
-            items:
-            - key: resolv.conf
-              path: resolv.conf
-          name: resolv-conf-volume


### PR DESCRIPTION
A small change to use the `ClusterFirstWithHostNet` dnsPolicy that landed in K8s 1.6 to avoid the override of the resolv.conf. Since it basically does the same thing the `hdfs-resolv-conf` can probably be retired unless K8s 1.5 support is still needed.