### PR TITLE
Jar with dependencies

### DIFF
--- a/topology/pod-cidr/pom.xml
+++ b/topology/pod-cidr/pom.xml
@@ -35,6 +35,22 @@
           <target>1.7</target>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <dependencies>


### PR DESCRIPTION
Build a jar with deps to have all needed classes when deploying in a hadoop cluster.

This is needed for e.g. the kubernetes client.

We could do better excluding the hadoop packages already present as jar in the hadoop distribution.