### PR TITLE
Add Kerberos test case in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 sudo: required
 
+env:
+  # Travis does not work well with minikube 0.26.x yet.
+  - CASES=_basic.sh K8S_VERSION=v1.9.4 MINIKUBE_VERSION=v0.25.2
+  - CASES=_kerberos.sh
+
 before_script:
 - USE_MINIKUBE_DRIVER_NONE=true USE_SUDO_MINIKUBE=true tests/setup.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 sudo: required
 
 env:
-  - USE_MINIKUBE_DRIVER_NONE=true USE_SUDO_MINIKUBE=true
+  - CASES=_basic.sh
+  - CASES=_kerberos.sh
 
 before_script:
-- tests/setup.sh
+- USE_MINIKUBE_DRIVER_NONE=true USE_SUDO_MINIKUBE=true tests/setup.sh
 
 script:
 - tests/run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_script:
 - USE_MINIKUBE_DRIVER_NONE=true USE_SUDO_MINIKUBE=true tests/setup.sh
 
 script:
-- tests/run.sh
+- DEBUG=true tests/run.sh
 
 after_script:
 - tests/cleanup.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 sudo: required
 
-env:
-  - CASES=_basic.sh
-  - CASES=_kerberos.sh
-
 before_script:
 - USE_MINIKUBE_DRIVER_NONE=true USE_SUDO_MINIKUBE=true tests/setup.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_script:
 - USE_MINIKUBE_DRIVER_NONE=true USE_SUDO_MINIKUBE=true tests/setup.sh
 
 script:
-- DEBUG=true tests/run.sh
+- tests/run.sh
 
 after_script:
 - tests/cleanup.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ env:
 before_script:
 # Required for K8s v1.10.x. See
 # https://github.com/kubernetes/kubernetes/issues/61058#issuecomment-372764783
-- sudo mount --make-shared /
-- sudo service docker restart
+- sudo mount --make-shared / && sudo service docker restart
 - USE_MINIKUBE_DRIVER_NONE=true USE_SUDO_MINIKUBE=true tests/setup.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ env:
   - CASES=_kerberos.sh
 
 before_script:
+- sudo mount --make-shared /
+- sudo service docker restart
 - USE_MINIKUBE_DRIVER_NONE=true USE_SUDO_MINIKUBE=true tests/setup.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 sudo: required
 
 env:
-  # Travis does not work well with minikube 0.26.x yet.
-  - CASES=_basic.sh K8S_VERSION=v1.9.4 MINIKUBE_VERSION=v0.25.2
+  - CASES=_basic.sh
   - CASES=_kerberos.sh
 
 before_script:
+# Required for K8s v1.10.x. See
+# https://github.com/kubernetes/kubernetes/issues/61058#issuecomment-372764783
 - sudo mount --make-shared /
 - sudo service docker restart
 - USE_MINIKUBE_DRIVER_NONE=true USE_SUDO_MINIKUBE=true tests/setup.sh

--- a/charts/hdfs-client/Chart.yaml
+++ b/charts/hdfs-client/Chart.yaml
@@ -1,17 +1,4 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+apiVersion: v1
 name: hdfs-client-k8s
-version: 0.2
+version: 0.2.0
 description: Hadoop Distributed File System (HDFS) hosted by Kubernetes.

--- a/charts/hdfs-datanode-k8s/Chart.yaml
+++ b/charts/hdfs-datanode-k8s/Chart.yaml
@@ -1,17 +1,4 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+apiVersion: v1
 name: hdfs-datanode-k8s
-version: 0.2
+version: 0.2.0
 description: Hadoop Distributed File System (HDFS) hosted by Kubernetes.

--- a/charts/hdfs-datanode-k8s/README.md
+++ b/charts/hdfs-datanode-k8s/README.md
@@ -25,7 +25,9 @@ HDFS `datanodes` running inside a kubernetes cluster. See the other chart for
      If enabling Kerberos, specify necessary options. For instance,
      ```
      $ helm install -n my-hdfs-datanode  \
-         --set kerberosEnabled=true,kerberosRealm=MYCOMPANY.COM hdfs-datanode-k8s
+         --set kerberosEnabled=true  \
+         --set kerberosRealm=MYCOMPANY.COM  \
+         hdfs-datanode-k8s
      ```
      The two variables above are required. For other variables, see values.yaml.
      If you have launched the non-HA namenode using

--- a/charts/hdfs-datanode-k8s/templates/datanode-daemonset.yaml
+++ b/charts/hdfs-datanode-k8s/templates/datanode-daemonset.yaml
@@ -48,9 +48,9 @@ spec:
             - name: HDFS_CONF_dfs_datanode_kerberos_principal
               value: hdfs/_HOST@{{ required "A valid kerberosRealm entry required!" .Values.kerberosRealm }}
             - name:  HDFS_CONF_dfs_datanode_kerberos_https_principal
-              value: http/_HOST@{{ required "A valid kerberosRealm entry required!" .Values.kerberosRealm }}
+              value: HTTP/_HOST@{{ required "A valid kerberosRealm entry required!" .Values.kerberosRealm }}
             - name: HDFS_CONF_dfs_web_authentication_kerberos_principal
-              value: http/_HOST@{{ required "A valid kerberosRealm entry required!" .Values.kerberosRealm }}
+              value: HTTP/_HOST@{{ required "A valid kerberosRealm entry required!" .Values.kerberosRealm }}
             - name: HDFS_CONF_dfs_datanode_keytab_file
               value: /etc/security/hdfs.keytab
             {{- if .Values.jsvcEnabled }}

--- a/charts/hdfs-journalnode-k8s/Chart.yaml
+++ b/charts/hdfs-journalnode-k8s/Chart.yaml
@@ -1,17 +1,4 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+apiVersion: v1
 name: hdfs-journalnode-k8s
-version: 0.2
+version: 0.2.0
 description: Hadoop Distributed File System (HDFS) hosted by Kubernetes.

--- a/charts/hdfs-journalnode-k8s/templates/journalnode-statefulset.yaml
+++ b/charts/hdfs-journalnode-k8s/templates/journalnode-statefulset.yaml
@@ -138,6 +138,17 @@ spec:
               mountPath: /kerberos-keytab-copy
       {{- end }}
       restartPolicy: Always
+      {{- if .Values.kerberosEnabled }}
+      volumes:
+        - name: kerberos-config
+          configMap:
+            name: {{ .Values.kerberosConfigMap }}
+        - name: kerberos-keytabs
+          secret:
+            secretName: {{ .Values.kerberosKeytabsSecret }}
+        - name: kerberos-keytab-copy
+          emptyDir: {}
+      {{- end }}
       {{- if .Values.podSecurityContext.enabled }}
       securityContext:
         runAsUser: {{ .Values.podSecurityContext.runAsUser }}

--- a/charts/hdfs-journalnode-k8s/templates/journalnode-statefulset.yaml
+++ b/charts/hdfs-journalnode-k8s/templates/journalnode-statefulset.yaml
@@ -85,11 +85,7 @@ spec:
               value: privacy
             - name: HDFS_CONF_dfs_journalnode_kerberos_principal
               value: hdfs/_HOST@{{ required "A valid kerberosRealm entry required!" .Values.kerberosRealm }}
-            # TODO: Check if the https principal is no longer needed in newer
-            # Hadoop version.
-            - name: HDFS_CONF_dfs_journalnode_kerberos_https_principal
-              value: HTTP/_HOST@{{ required "A valid kerberosRealm entry required!" .Values.kerberosRealm }}
-            - name: HDFS_CONF_dfs_web_authentication_kerberos_principal
+            - name: HDFS_CONF_dfs_journalnode_kerberos_internal_spnego_principal
               value: HTTP/_HOST@{{ required "A valid kerberosRealm entry required!" .Values.kerberosRealm }}
             - name: HDFS_CONF_dfs_journalnode_keytab_file
               value: /etc/security/hdfs.keytab

--- a/charts/hdfs-journalnode-k8s/templates/journalnode-statefulset.yaml
+++ b/charts/hdfs-journalnode-k8s/templates/journalnode-statefulset.yaml
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO: Support Kerberos for journal nodes.
-
 # A headless service to create DNS records.
 apiVersion: v1
 kind: Service
@@ -78,6 +76,24 @@ spec:
           env:
             # The following env vars are listed according to low-to-high precedence order.
             # i.e. Whoever comes last will override the earlier value of the same variable.
+          {{- if .Values.kerberosEnabled }}
+            - name: CORE_CONF_hadoop_security_authentication
+              value: kerberos
+            - name: CORE_CONF_hadoop_security_authorization
+              value: "true"
+            - name: CORE_CONF_hadoop_rpc_protection
+              value: privacy
+            - name: HDFS_CONF_dfs_journalnode_kerberos_principal
+              value: hdfs/_HOST@{{ required "A valid kerberosRealm entry required!" .Values.kerberosRealm }}
+            # TODO: Check if the https principal is no longer needed in newer
+            # Hadoop version.
+            - name: HDFS_CONF_dfs_journalnode_kerberos_https_principal
+              value: HTTP/_HOST@{{ required "A valid kerberosRealm entry required!" .Values.kerberosRealm }}
+            - name: HDFS_CONF_dfs_web_authentication_kerberos_principal
+              value: HTTP/_HOST@{{ required "A valid kerberosRealm entry required!" .Values.kerberosRealm }}
+            - name: HDFS_CONF_dfs_journalnode_keytab_file
+              value: /etc/security/hdfs.keytab
+            {{- end }}
             {{- range $key, $value := .Values.customHadoopConfig }}
             - name: {{ $key | quote }}
               value: {{ $value | quote }}
@@ -94,6 +110,33 @@ spec:
           volumeMounts:
             - name: editdir
               mountPath: /hadoop/dfs/journal
+           {{- if .Values.kerberosEnabled }}
+            - name: kerberos-config
+              mountPath: /etc/krb5.conf
+              subPath: {{ .Values.kerberosConfigFileName }}
+              readOnly: true
+            - name: kerberos-keytab-copy
+              mountPath: /etc/security/
+              readOnly: true
+            {{- end }}
+     {{- if .Values.kerberosEnabled }}
+      initContainers:
+        - name: copy-kerberos-keytab
+          image: busybox:1.27.1
+          command: ['sh', '-c']
+          args:
+            - cp /kerberos-keytabs/${MY_KERBEROS_NAME}*.keytab /kerberos-keytab-copy/hdfs.keytab
+          env:
+            - name: MY_KERBEROS_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          volumeMounts:
+            - name: kerberos-keytabs
+              mountPath: /kerberos-keytabs
+            - name: kerberos-keytab-copy
+              mountPath: /kerberos-keytab-copy
+      {{- end }}
       restartPolicy: Always
       {{- if .Values.podSecurityContext.enabled }}
       securityContext:

--- a/charts/hdfs-journalnode-k8s/values.yaml
+++ b/charts/hdfs-journalnode-k8s/values.yaml
@@ -27,3 +27,26 @@ podSecurityContext:
   enabled: false
   runAsUser: 0
   fsGroup: 1000
+
+# Whether or not Kerberos support is enabled.
+kerberosEnabled: false
+
+# Required to be non-empty if Kerberos is enabled. Specify your Kerberos realm name.
+# This should match the realm name in your Kerberos config file.
+kerberosRealm: ""
+
+# Effective only if Kerberos is enabled. Name of the k8s config map containing
+# the kerberos config file.
+kerberosConfigMap: kerberos-config
+
+# Effective only if Kerberos is enabled. Name of the kerberos config file inside
+# the config map.
+kerberosConfigFileName: krb5.conf
+
+# Effective only if Kerberos is enabled. Name of the k8s secret containing
+# the kerberos keytab files of per-host HDFS principals. The secret should
+# have multiple data items. Each data item name should be formatted as:
+#    `HOST-NAME.keytab`
+# where HOST-NAME should match the cluster node
+# host name that each per-host hdfs principal is associated with.
+kerberosKeytabsSecret: hdfs-kerberos-keytabs

--- a/charts/hdfs-namenode-k8s/Chart.yaml
+++ b/charts/hdfs-namenode-k8s/Chart.yaml
@@ -1,17 +1,4 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+apiVersion: v1
 name: hdfs-namenode-k8s
-version: 0.2
+version: 0.2.0
 description: Hadoop Distributed File System (HDFS) hosted by Kubernetes.

--- a/charts/hdfs-namenode-k8s/README.md
+++ b/charts/hdfs-namenode-k8s/README.md
@@ -48,6 +48,11 @@ See the other chart for `datanodes`.
         $ kubectl create configmap kerberos-config --from-file=/etc/krb5.conf
        ```
 
+       We have our own kerberos server in the `krb5-server` helm chart.
+       Currently, this is used mainly by the integration tests. But you may
+       choose to use this for your cluster as well. For details, see
+       the integration test case `tests/cases/_kerberos.sh`.
+
      - Generate per-host principal accounts and password keytab files for the namenode
        and datanode daemons. This is typically done in your Kerberos KDC host. For example,
        suppose the namenode will run on the k8s cluster node kube-n1.mycompany.com,

--- a/charts/hdfs-namenode-k8s/README.md
+++ b/charts/hdfs-namenode-k8s/README.md
@@ -56,23 +56,23 @@ See the other chart for `datanodes`.
 
        ```
         $ kadmin.local -q "addprinc -randkey hdfs/kube-n1.mycompany.com@MYCOMPANY.COM"
-        $ kadmin.local -q "addprinc -randkey http/kube-n1.mycompany.com@MYCOMPANY.COM"
+        $ kadmin.local -q "addprinc -randkey HTTP/kube-n1.mycompany.com@MYCOMPANY.COM"
         $ mkdir hdfs-keytabs
         $ kadmin.local -q "ktadd -norandkey  \
                   -k hdfs-keytabs/kube-n1.mycompany.com.keytab  \
                   hdfs/kube-n1.mycompany.com@MYCOMPANY.COM  \
-                  http/kube-n1.mycompany.com@MYCOMPANY.COM"
+                  HTTP/kube-n1.mycompany.com@MYCOMPANY.COM"
 
         $ kadmin.local -q "addprinc -randkey hdfs/kube-n2.mycompany.com@MYCOMPANY.COM"
-        $ kadmin.local -q "addprinc -randkey http/kube-n2.mycompany.com@MYCOMPANY.COM"
+        $ kadmin.local -q "addprinc -randkey HTTP/kube-n2.mycompany.com@MYCOMPANY.COM"
         $ kadmin.local -q "ktadd -norandkey  \
                   -k hdfs-keytabs/kube-n2.mycompany.com.keytab  \
                   hdfs/kube-n2.mycompany.com@MYCOMPANY.COM  \
-                  http/kube-n2.mycompany.com@MYCOMPANY.COM"
+                  HTTP/kube-n2.mycompany.com@MYCOMPANY.COM"
         $ kadmin.local -q "ktadd -norandkey  \
                   -k hdfs-keytabs/kube-n2.mycompany.com.keytab  \
                   hdfs/kube-n2.mycompany.com@MYCOMPANY.COM  \
-                  http/kube-n2.mycompany.com@MYCOMPANY.COM"
+                  HTTP/kube-n2.mycompany.com@MYCOMPANY.COM"
        ```
 
      - Create a k8s secret containing all the keytab files. This will be mounted

--- a/charts/hdfs-namenode-k8s/README.md
+++ b/charts/hdfs-namenode-k8s/README.md
@@ -120,7 +120,9 @@ See the other chart for `datanodes`.
      If enabling Kerberos, specify necessary options. For instance,
      ```
      $ helm install -n my-hdfs-namenode  \
-         --set kerberosEnabled=true,kerberosRealm=MYCOMPANY.COM hdfs-namenode-k8s
+         --set kerberosEnabled=true  \
+         --set kerberosRealm=MYCOMPANY.COM  \
+         hdfs-namenode-k8s
      ```
      The two variables above are required. For other variables, see values.yaml.
 
@@ -128,7 +130,9 @@ See the other chart for `datanodes`.
      the namenodePinningEnabled option:
      ```
      $ helm install -n my-hdfs-namenode  \
-         --set kerberosEnabled=true,kerberosRealm=MYCOMPANY.COM,namenodePinningEnabled=true \
+         --set kerberosEnabled=true  \
+         --set kerberosRealm=MYCOMPANY.COM  \
+         --set namenodePinningEnabled=true \
          hdfs-namenode-k8s
      ```
 

--- a/charts/hdfs-namenode-k8s/templates/namenode-statefulset.yaml
+++ b/charts/hdfs-namenode-k8s/templates/namenode-statefulset.yaml
@@ -223,12 +223,16 @@ spec:
           image: busybox:1.27.1
           command: ['sh', '-c']
           args:
-            - cp /kerberos-keytabs/$MY_NODE_NAME.keytab /kerberos-keytab-copy/hdfs.keytab
+            - cp /kerberos-keytabs/${MY_KERBEROS_NAME}*.keytab /kerberos-keytab-copy/hdfs.keytab
           env:
-            - name: MY_NODE_NAME
+            - name: MY_KERBEROS_NAME
               valueFrom:
                 fieldRef:
+                {{- if .Values.hostNetworkEnabled }}
                   fieldPath: spec.nodeName
+                {{- else }}
+                  fieldPath: metadata.name
+                {{- end }}
           volumeMounts:
             - name: kerberos-keytabs
               mountPath: /kerberos-keytabs

--- a/charts/hdfs-namenode-k8s/templates/namenode-statefulset.yaml
+++ b/charts/hdfs-namenode-k8s/templates/namenode-statefulset.yaml
@@ -150,9 +150,9 @@ spec:
             # TODO: Check if the https principal is no longer needed in newer
             # Hadoop version.
             - name: HDFS_CONF_dfs_namenode_kerberos_https_principal
-              value: http/_HOST@{{ required "A valid kerberosRealm entry required!" .Values.kerberosRealm }}
+              value: HTTP/_HOST@{{ required "A valid kerberosRealm entry required!" .Values.kerberosRealm }}
             - name: HDFS_CONF_dfs_web_authentication_kerberos_principal
-              value: http/_HOST@{{ required "A valid kerberosRealm entry required!" .Values.kerberosRealm }}
+              value: HTTP/_HOST@{{ required "A valid kerberosRealm entry required!" .Values.kerberosRealm }}
             - name: HDFS_CONF_dfs_namenode_keytab_file
               value: /etc/security/hdfs.keytab
             {{- end }}

--- a/charts/hdfs-namenode-k8s/templates/namenode-statefulset.yaml
+++ b/charts/hdfs-namenode-k8s/templates/namenode-statefulset.yaml
@@ -155,6 +155,10 @@ spec:
               value: HTTP/_HOST@{{ required "A valid kerberosRealm entry required!" .Values.kerberosRealm }}
             - name: HDFS_CONF_dfs_namenode_keytab_file
               value: /etc/security/hdfs.keytab
+            - name: HDFS_CONF_dfs_journalnode_kerberos_principal
+              value: hdfs/_HOST@{{ required "A valid kerberosRealm entry required!" .Values.kerberosRealm }}
+            - name: HDFS_CONF_dfs_journalnode_kerberos_internal_spnego_principal
+              value: HTTP/_HOST@{{ required "A valid kerberosRealm entry required!" .Values.kerberosRealm }}
             {{- end }}
             {{- range $key, $value := .Values.customHadoopConfig }}
             - name: {{ $key | quote }}

--- a/charts/hdfs-simple-namenode-k8s/Chart.yaml
+++ b/charts/hdfs-simple-namenode-k8s/Chart.yaml
@@ -1,17 +1,4 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+apiVersion: v1
 name: hdfs-simple-namenode-k8s
-version: 0.2
+version: 0.2.0
 description: Hadoop Distributed File System (HDFS) hosted by Kubernetes.

--- a/charts/krb5-server/.helmignore
+++ b/charts/krb5-server/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/krb5-server/Chart.yaml
+++ b/charts/krb5-server/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Kerberos server
+name: krb5-server
+version: 0.1.0

--- a/charts/krb5-server/README.md
+++ b/charts/krb5-server/README.md
@@ -1,0 +1,8 @@
+---
+layout: global
+title: Kerberos server chart
+---
+
+# Kerberos server chart
+Helm charts for launching a Kerberos server. Currently, this is used mainly
+for integration tests.

--- a/charts/krb5-server/templates/_helpers.tpl
+++ b/charts/krb5-server/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "krb5-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "krb5-server.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "krb5-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/krb5-server/templates/deployment.yaml
+++ b/charts/krb5-server/templates/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "krb5-server.fullname" . }}
+  labels:
+    app: {{ template "krb5-server.name" . }}
+    chart: {{ template "krb5-server.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "krb5-server.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "krb5-server.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: KRB5_REALM
+              value: EXAMPLE.COM
+            - name: KRB5_KDC
+              value: localhost
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/charts/krb5-server/templates/service.yaml
+++ b/charts/krb5-server/templates/service.yaml
@@ -1,19 +1,23 @@
+# A headless service to create DNS records.
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "krb5-server.fullname" . }}
+  name: krb5-server
   labels:
-    app: {{ template "krb5-server.name" . }}
-    chart: {{ template "krb5-server.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app: krb5-server
+  annotations:
+    # TODO: Deprecated. Replace tolerate-unready-endpoints with
+    # v1.Service.PublishNotReadyAddresses.
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
-  type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
       protocol: TCP
-      name: http
+      name: kdc-tcp
+    - port: {{ .Values.service.port }}
+      protocol: UDP
+      name: kdc-udp
+  clusterIP: None
   selector:
     app: {{ template "krb5-server.name" . }}
     release: {{ .Release.Name }}

--- a/charts/krb5-server/templates/service.yaml
+++ b/charts/krb5-server/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "krb5-server.fullname" . }}
+  labels:
+    app: {{ template "krb5-server.name" . }}
+    chart: {{ template "krb5-server.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "krb5-server.name" . }}
+    release: {{ .Release.Name }}

--- a/charts/krb5-server/templates/statefulset.yaml
+++ b/charts/krb5-server/templates/statefulset.yaml
@@ -28,7 +28,7 @@ spec:
             - name: KRB5_REALM
               value: {{ .Values.realm }}
             - name: KRB5_KDC
-              value: localhost
+              value: {{ template "krb5-server.fullname" . }}-0.{{ template "krb5-server.name" . }}..default.svc.cluster.local
           ports:
             - name: kdc-tcp
               containerPort: 88

--- a/charts/krb5-server/templates/statefulset.yaml
+++ b/charts/krb5-server/templates/statefulset.yaml
@@ -1,5 +1,5 @@
-apiVersion: apps/v1beta2
-kind: Deployment
+apiVersion: apps/v1beta1
+kind: StatefulSet
 metadata:
   name: {{ template "krb5-server.fullname" . }}
   labels:
@@ -8,6 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  serviceName: "krb5-server"
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
@@ -25,32 +26,33 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: KRB5_REALM
-              value: EXAMPLE.COM
+              value: {{ .Values.realm }}
             - name: KRB5_KDC
               value: localhost
           ports:
-            - name: http
-              containerPort: 80
+            - name: kdc-tcp
+              containerPort: 88
               protocol: TCP
+            - name: kdc-udp
+              containerPort: 88
+              protocol: UDP
           livenessProbe:
-            httpGet:
-              path: /
-              port: http
+            tcpSocket:
+              port: kdc-tcp
           readinessProbe:
-            httpGet:
-              path: /
-              port: http
-          resources:
-{{ toYaml .Values.resources | indent 12 }}
-    {{- with .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.affinity }}
-      affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
-      tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+            tcpSocket:
+              port: kdc-tcp
+      restartPolicy: Always
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.podSecurityContext.runAsUser }}
+        fsGroup: {{ .Values.podSecurityContext.fsGroup }}
+      {{- end }}
+  volumeClaimTemplates:
+  - metadata:
+      name: datadir
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: {{ .Values.dataVolumeSize }}

--- a/charts/krb5-server/templates/statefulset.yaml
+++ b/charts/krb5-server/templates/statefulset.yaml
@@ -28,7 +28,7 @@ spec:
             - name: KRB5_REALM
               value: {{ .Values.realm }}
             - name: KRB5_KDC
-              value: {{ template "krb5-server.fullname" . }}-0.{{ template "krb5-server.name" . }}..default.svc.cluster.local
+              value: {{ template "krb5-server.fullname" . }}-0.{{ template "krb5-server.name" . }}.default.svc.cluster.local
           ports:
             - name: kdc-tcp
               containerPort: 88

--- a/charts/krb5-server/values.yaml
+++ b/charts/krb5-server/values.yaml
@@ -1,0 +1,13 @@
+# Default values for krb5-server.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: gcavalcante8808/krb5-server
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+

--- a/charts/krb5-server/values.yaml
+++ b/charts/krb5-server/values.yaml
@@ -2,12 +2,26 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# Your Kerberos realm
+realm: MYCOMPANY.COM
+
+# Size of editata persistent volume per journalnode instance.
+dataVolumeSize: 20Gi
+
+# Parameters for determining which Unix user and group IDs to use in pods.
+# Persistent volume permission may need to match these.
+podSecurityContext:
+  enabled: false
+  runAsUser: 0
+  fsGroup: 1000
+
 image:
   repository: gcavalcante8808/krb5-server
+  # TODO: Using latest tag is not desirable. The current image does not have specific tags.
+  # Find a way to fix it.
   tag: latest
   pullPolicy: IfNotPresent
 
 service:
   type: ClusterIP
-  port: 80
-
+  port: 88

--- a/charts/krb5-server/values.yaml
+++ b/charts/krb5-server/values.yaml
@@ -15,10 +15,15 @@ podSecurityContext:
   runAsUser: 0
   fsGroup: 1000
 
+# We use a 3rd party image built from https://github.com/gcavalcante8808/docker-krb5-server.
+# TODO: The pod currently prints out the admin account in plain text.
+# Supply an admin account password using a k8s secret.
+# TODO: The auto-generated passwords might be weak due to low entropy.
+# Increase entropy by running rngd or haveged.
+# TODO: Using latest tag is not desirable. The current image does not have specific tags.
+# Find a way to fix it.
 image:
   repository: gcavalcante8808/krb5-server
-  # TODO: Using latest tag is not desirable. The current image does not have specific tags.
-  # Find a way to fix it.
   tag: latest
   pullPolicy: IfNotPresent
 

--- a/tests/cases/_basic.sh
+++ b/tests/cases/_basic.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+function run_test_case () {
+  _run helm install zookeeper  \
+    --name my-zk  \
+    --version 0.6.3 \
+    --repo https://kubernetes-charts-incubator.storage.googleapis.com/  \
+    --set servers=1,heap=100m,resources.requests.memory=100m
+  k8s_single_pod_ready -l app=zookeeper
+
+  _run helm install hdfs-journalnode-k8s  \
+    --name my-hdfs-journalnode
+  k8s_all_pods_ready 3 -l app=hdfs-journalnode
+
+  # Disables hostNetwork so namenode pods on a single minikube node can avoid
+  # port conflict
+  _run helm install hdfs-namenode-k8s  \
+    --name my-hdfs-namenode  \
+    --set hostNetworkEnabled=false,zookeeperQuorum=my-zk-zookeeper-0.my-zk-zookeeper-headless.default.svc.cluster.local:2181
+  k8s_all_pods_ready 2 -l app=hdfs-namenode
+
+  _run helm install hdfs-datanode-k8s  \
+    --name my-hdfs-datanode  \
+    --set "dataNodeHostPath={/mnt/sda1/hdfs-data}"
+  k8s_single_pod_ready -l name=hdfs-datanode
+
+  echo All pods:
+  kubectl get pods
+
+  echo All persistent volumes:
+  kubectl get pv
+
+  _run helm install hdfs-client  \
+    --name my-hdfs-client
+  k8s_single_pod_ready -l app=hdfs-client
+  _CLIENT=$(kubectl get pods -l app=hdfs-client -o name| cut -d/ -f 2)
+  echo Found client pod $_CLIENT
+
+  _run kubectl exec $_CLIENT -- hdfs dfsadmin -report
+  _run kubectl exec $_CLIENT -- hdfs haadmin -getServiceState nn0
+  _run kubectl exec $_CLIENT -- hdfs haadmin -getServiceState nn1
+
+  _run kubectl exec $_CLIENT -- hadoop fs -rm -r -f /tmp
+  _run kubectl exec $_CLIENT -- hadoop fs -mkdir /tmp
+  _run kubectl exec $_CLIENT -- sh -c  \
+    "(head -c 100M < /dev/urandom > /tmp/random-100M)"
+  _run kubectl exec $_CLIENT -- hadoop fs -copyFromLocal /tmp/random-100M /tmp
+}

--- a/tests/cases/_basic.sh
+++ b/tests/cases/_basic.sh
@@ -46,3 +46,14 @@ function run_test_case () {
     "(head -c 100M < /dev/urandom > /tmp/random-100M)"
   _run kubectl exec $_CLIENT -- hadoop fs -copyFromLocal /tmp/random-100M /tmp
 }
+
+function cleanup_test_case() {
+  local charts="my-hdfs-client  \
+    my-hdfs-datanode  \
+    my-hdfs-namenode  \
+    my-hdfs-journalnode  \
+    my-zk"
+  for chart in $charts; do
+    helm delete --purge $chart || true
+  done
+}

--- a/tests/cases/_kerberos.sh
+++ b/tests/cases/_kerberos.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+function run_test_case () {
+  _run helm install krb5-server  \
+    --name my-krb5-server
+  k8s_single_pod_ready -l app=krb5-server
+
+  _run helm install zookeeper  \
+    --name my-zk  \
+    --version 0.6.3 \
+    --repo https://kubernetes-charts-incubator.storage.googleapis.com/  \
+    --set servers=1,heap=100m,resources.requests.memory=100m
+  k8s_single_pod_ready -l app=zookeeper
+
+  _run helm install hdfs-journalnode-k8s  \
+    --name my-hdfs-journalnode
+  k8s_all_pods_ready 3 -l app=hdfs-journalnode
+
+  # Disables hostNetwork so namenode pods on a single minikube node can avoid
+  # port conflict
+  _run helm install hdfs-namenode-k8s  \
+    --name my-hdfs-namenode  \
+    --set hostNetworkEnabled=false,zookeeperQuorum=my-zk-zookeeper-0.my-zk-zookeeper-headless.default.svc.cluster.local:2181
+  k8s_all_pods_ready 2 -l app=hdfs-namenode
+
+  _run helm install hdfs-datanode-k8s  \
+    --name my-hdfs-datanode  \
+    --set "dataNodeHostPath={/mnt/sda1/hdfs-data}"
+  k8s_single_pod_ready -l name=hdfs-datanode
+
+  echo All pods:
+  kubectl get pods
+
+  echo All persistent volumes:
+  kubectl get pv
+
+  _run helm install hdfs-client  \
+    --name my-hdfs-client
+  k8s_single_pod_ready -l app=hdfs-client
+  _CLIENT=$(kubectl get pods -l app=hdfs-client -o name| cut -d/ -f 2)
+  echo Found client pod $_CLIENT
+
+  _run kubectl exec $_CLIENT -- hdfs dfsadmin -report
+  _run kubectl exec $_CLIENT -- hdfs haadmin -getServiceState nn0
+  _run kubectl exec $_CLIENT -- hdfs haadmin -getServiceState nn1
+
+  _run kubectl exec $_CLIENT -- hadoop fs -rm -r -f /tmp
+  _run kubectl exec $_CLIENT -- hadoop fs -mkdir /tmp
+  _run kubectl exec $_CLIENT -- sh -c  \
+    "(head -c 100M < /dev/urandom > /tmp/random-100M)"
+  _run kubectl exec $_CLIENT -- hadoop fs -copyFromLocal /tmp/random-100M /tmp
+}

--- a/tests/cases/_kerberos.sh
+++ b/tests/cases/_kerberos.sh
@@ -69,7 +69,7 @@ function run_test_case () {
   kubectl exec $_NN0 -- sh -c "(apt install -y krb5-user > /dev/null)"  \
     || true
   _run kubectl exec $_NN0 --   \
-    kinit -t /etc/security/hdfs.keytab  \
+    kinit -kt /etc/security/hdfs.keytab  \
     hdfs/hdfs-namenode-0.hdfs-namenode.default.svc.cluster.local@MYCOMPANY.COM
   _run kubectl exec $_NN0 -- hdfs dfsadmin -report
   _run kubectl exec $_NN0 -- hdfs haadmin -getServiceState nn0
@@ -95,7 +95,7 @@ function run_test_case () {
   kubectl exec $_CLIENT -- sh -c "(apt install -y krb5-user > /dev/null)"  \
     || true
 
-  _run kubectl exec $_CLIENT -- kinit -t /tmp/user1.keytab user1@MYCOMPANY.COM
+  _run kubectl exec $_CLIENT -- kinit -kt /tmp/user1.keytab user1@MYCOMPANY.COM
   _run kubectl exec $_CLIENT -- sh -c  \
     "(head -c 100M < /dev/urandom > /tmp/random-100M)"
   _run kubectl exec $_CLIENT -- hadoop fs -ls /

--- a/tests/cases/_kerberos.sh
+++ b/tests/cases/_kerberos.sh
@@ -66,7 +66,8 @@ function run_test_case () {
   kubectl get pv
 
   _NN0=hdfs-namenode-0
-  kubectl exec $_NN0 -- apt install -y krb5-user || true
+  kubectl exec $_NN0 -- sh -c "(apt install -y krb5-user > /dev/null)"  \
+    || true
   _run kubectl exec $_NN0 --   \
     kinit -t /etc/security/hdfs.keytab  \
     hdfs/hdfs-namenode-0.hdfs-namenode.default.svc.cluster.local@MYCOMPANY.COM
@@ -91,7 +92,8 @@ function run_test_case () {
   _run kubectl cp $_KDC:/tmp/user1.keytab $_TEST_DIR/tmp/user1.keytab
   _run kubectl cp $_TEST_DIR/tmp/user1.keytab $_CLIENT:/tmp/user1.keytab
 
-  kubectl exec $_CLIENT -- apt install -y krb5-user || true
+  kubectl exec $_CLIENT -- sh -c "(apt install -y krb5-user > /dev/null)"  \
+    || true
 
   _run kubectl exec $_CLIENT -- kinit -t /tmp/user1.keytab user1@MYCOMPANY.COM
   _run kubectl exec $_CLIENT -- sh -c  \

--- a/tests/cases/_kerberos.sh
+++ b/tests/cases/_kerberos.sh
@@ -50,3 +50,15 @@ function run_test_case () {
     "(head -c 100M < /dev/urandom > /tmp/random-100M)"
   _run kubectl exec $_CLIENT -- hadoop fs -copyFromLocal /tmp/random-100M /tmp
 }
+
+function cleanup_test_case() {
+  local charts="my-hdfs-client  \
+    my-hdfs-datanode  \
+    my-hdfs-namenode  \
+    my-hdfs-journalnode  \
+    my-zk  \
+    my-krb5-server"
+  for chart in $charts; do
+    helm delete --purge $chart || true
+  done
+}

--- a/tests/cleanup.sh
+++ b/tests/cleanup.sh
@@ -14,17 +14,16 @@ if [[ "${DEBUG:-}" = "true" ]]; then
 fi
 
 _MY_SCRIPT="${BASH_SOURCE[0]}"
-_MY_DIR=$(cd "$(dirname "$_MY_SCRIPT")" && pwd)
+_TEST_DIR=$(cd "$(dirname "$_MY_SCRIPT")" && pwd)
 
-cd $_MY_DIR
-export PATH=${_MY_DIR}/bin:$PATH
+cd $_TEST_DIR
+export PATH=${_TEST_DIR}/bin:$PATH
 
-_CHARTS="my-hdfs-client  \
-  my-hdfs-datanode  \
-  my-hdfs-namenode  \
-  my-hdfs-journalnode  \
-  my-zk  \
-  my-krb5-server"
-for chart in $_CHARTS; do
-  helm delete --purge $chart || true
-done
+_DEFAULT_CASES="*"
+: "${CASES:=$_DEFAULT_CASES}"
+_CASES=$(ls ${_TEST_DIR}/cases/${CASES})
+for _CASE in $_CASES; do
+  source $_CASE
+  echo Cleaning up test case: $_CASE
+  cleanup_test_case
+ done

--- a/tests/cleanup.sh
+++ b/tests/cleanup.sh
@@ -23,7 +23,8 @@ _CHARTS="my-hdfs-client  \
   my-hdfs-datanode  \
   my-hdfs-namenode  \
   my-hdfs-journalnode  \
-  my-zk"
+  my-zk  \
+  my-krb5-server"
 for chart in $_CHARTS; do
   helm delete --purge $chart || true
 done

--- a/tests/lib/_k8s.sh
+++ b/tests/lib/_k8s.sh
@@ -7,7 +7,7 @@ function _wait_for_ready () {
   local evidence="$1"
   shift
   local attempts=40
-  echo "Waiting till $count ready: $@"
+  echo "Waiting till ready (count: $count): $@"
   while [[ "$count" != $("$@" 2>&1 | tail -n +2 | grep -c $evidence) ]];
   do
     if [[ "$attempts" = "1" ]]; then

--- a/tests/lib/_k8s.sh
+++ b/tests/lib/_k8s.sh
@@ -15,7 +15,7 @@ function _wait_for_ready () {
       "$@" || true
       local command="$@"
       command="${command/get/describe}"
-      "$command" || true
+      $command || true
     fi
     ((attempts--)) || return 1
     sleep 5
@@ -27,7 +27,8 @@ function _wait_for_ready () {
 function k8s_all_nodes_ready () {
   local count="$1"
   shift
-  _wait_for_ready "$count" " Ready" kubectl get nodes
+  _wait_for_ready "$count" "-v NotReady" kubectl get nodes
+  _wait_for_ready "$count" Ready kubectl get nodes
 }
 
 function k8s_single_node_ready () {

--- a/tests/lib/_k8s.sh
+++ b/tests/lib/_k8s.sh
@@ -7,7 +7,7 @@ function _wait_for_ready () {
   local evidence="$1"
   shift
   local attempts=40
-  echo "Running: $@"
+  echo "Waiting till $count ready: $@"
   while [[ "$count" != $("$@" 2>&1 | tail -n +2 | grep -c $evidence) ]];
   do
     if [[ "$attempts" = "1" ]]; then

--- a/tests/lib/_k8s.sh
+++ b/tests/lib/_k8s.sh
@@ -11,6 +11,7 @@ function _wait_for_ready () {
   while [[ "$count" != $("$@" 2>&1 | tail -n +2 | grep -c $evidence) ]];
   do
     if [[ "$attempts" = 1 ]]; then
+      echo The last attempt: "$@"
       "$@" || true
     fi
     ((attempts--)) || return 1

--- a/tests/lib/_k8s.sh
+++ b/tests/lib/_k8s.sh
@@ -10,10 +10,6 @@ function _wait_for_ready () {
   echo "Running: $@"
   while [[ "$count" != $("$@" 2>&1 | tail -n +2 | grep -c $evidence) ]];
   do
-    if [[ "$attempts" = 1 ]]; then
-      echo The last attempt: "$@"
-      "$@" || true
-    fi
     ((attempts--)) || return 1
     sleep 5
   done
@@ -37,7 +33,14 @@ function k8s_single_node_ready () {
 function k8s_all_pods_ready () {
   local count="$1"
   shift
-  _wait_for_ready "$count" "-e 1/1 -e 2/2 -e 3/3 -e 4/4" kubectl get pods "$@"
+  local evidence="-e 1/1 -e 2/2 -e 3/3 -e 4/4"
+  _wait_for_ready "$count" "$evidence" kubectl get pods "$@"
+  if [[ "$?" != "0" ]]; then
+    kubectl get pods "$@" || true
+    kubectl describe pods "$@" || true
+    return 1
+  fi
+  return 0
 }
 
 function k8s_single_pod_ready () {

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -22,10 +22,6 @@ source ${_TEST_DIR}/lib/_k8s.sh
 _PROJECT_DIR=$(cd "$(dirname "$_TEST_DIR")" && pwd)
 _CHART_DIR=${_PROJECT_DIR}/charts
 
-cd $_CHART_DIR
-
-kubectl cluster-info
-
 function _run () {
   local attempts=2
   echo Running: "$@"
@@ -35,51 +31,15 @@ function _run () {
   done
 }
 
-_run helm install krb5-server  \
-  --name my-krb5-server
-k8s_single_pod_ready -l app=krb5-server
+kubectl cluster-info
+cd $_CHART_DIR
 
-_run helm install zookeeper  \
-  --name my-zk  \
-  --version 0.6.3 \
-  --repo https://kubernetes-charts-incubator.storage.googleapis.com/  \
-  --set servers=1,heap=100m,resources.requests.memory=100m
-k8s_single_pod_ready -l app=zookeeper
-
-_run helm install hdfs-journalnode-k8s  \
-  --name my-hdfs-journalnode
-k8s_all_pods_ready 3 -l app=hdfs-journalnode
-
-# Disables hostNetwork so namenode pods on a single minikube node can avoid
-# port conflict
-_run helm install hdfs-namenode-k8s  \
-  --name my-hdfs-namenode  \
-  --set hostNetworkEnabled=false,zookeeperQuorum=my-zk-zookeeper-0.my-zk-zookeeper-headless.default.svc.cluster.local:2181
-k8s_all_pods_ready 2 -l app=hdfs-namenode
-
-_run helm install hdfs-datanode-k8s  \
-  --name my-hdfs-datanode  \
-  --set "dataNodeHostPath={/mnt/sda1/hdfs-data}"
-k8s_single_pod_ready -l name=hdfs-datanode
-
-echo All pods:
-kubectl get pods
-
-echo All persistent volumes:
-kubectl get pv
-
-_run helm install hdfs-client  \
-  --name my-hdfs-client
-k8s_single_pod_ready -l app=hdfs-client
-_CLIENT=$(kubectl get pods -l app=hdfs-client -o name| cut -d/ -f 2)
-echo Found client pod $_CLIENT
-
-_run kubectl exec $_CLIENT -- hdfs dfsadmin -report
-_run kubectl exec $_CLIENT -- hdfs haadmin -getServiceState nn0
-_run kubectl exec $_CLIENT -- hdfs haadmin -getServiceState nn1
-
-_run kubectl exec $_CLIENT -- hadoop fs -rm -r -f /tmp
-_run kubectl exec $_CLIENT -- hadoop fs -mkdir /tmp
-_run kubectl exec $_CLIENT -- sh -c  \
-  "(head -c 100M < /dev/urandom > /tmp/random-100M)"
-_run kubectl exec $_CLIENT -- hadoop fs -copyFromLocal /tmp/random-100M /tmp
+_DEFAULT_CASES="*"
+: "${CASES:=$_DEFAULT_CASES}"
+_CASES=$(ls ${_TEST_DIR}/cases/${CASES})
+for _CASE in $_CASES; do
+  echo Running test case: $_CASE
+  source $_CASE
+  run_test_case
+  $_TEST_DIR/cleanup.sh
+done

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -42,6 +42,7 @@ for _CASE in $_CASES; do
   source $_CASE
   run_test_case
   if [[ "${SKIP_CLEANUP:-false}" = "false" ]]; then
+    echo Cleaning up test case: $_CASE
     cleanup_test_case
   fi
 done

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -41,5 +41,7 @@ for _CASE in $_CASES; do
   echo Running test case: $_CASE
   source $_CASE
   run_test_case
-  $_TEST_DIR/cleanup.sh
+  if [[ "${SKIP_CLEANUP:-false}" = "false" ]]; then
+    cleanup_test_case
+  fi
 done

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -35,6 +35,10 @@ function _run () {
   done
 }
 
+_run helm install krb5-server  \
+  --name my-krb5-server
+k8s_single_pod_ready -l app=krb5-server
+
 _run helm install zookeeper  \
   --name my-zk  \
   --version 0.6.3 \

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -121,8 +121,10 @@ echo Showing kube-system pods
 kubectl get -n kube-system pods
 
 _ADDON=$(kubectl get pod -n kube-system -l component=kube-addon-manager --no-headers -o name| cut -d/ -f2)
+echo Addon-manager log:
 kubectl logs -n kube-system $_ADDON
 k8s_all_pods_ready 4 -n kube-system || true
+echo Addon-manager log:
 kubectl logs -n kube-system $_ADDON
 k8s_all_pods_ready 4 -n kube-system
 

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -17,6 +17,9 @@ fi
 _MY_SCRIPT="${BASH_SOURCE[0]}"
 _MY_DIR=$(cd "$(dirname "$_MY_SCRIPT")" && pwd)
 # Avoids 1.7.x because of https://github.com/kubernetes/minikube/issues/2240
+# Also avoids 1.9.4 because of
+# https://github.com/kubernetes/kubernetes/issues/61076#issuecomment-376660233
+# TODO: Try 1.9.x > 1.9.4 when a new minikube version supports that.
 _DEFAULT_K8S_VERSION=v1.10.0
 : "${K8S_VERSION:=$_DEFAULT_K8S_VERSION}"
 _DEFAULT_MINIKUBE_VERSION=v0.26.0

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -124,6 +124,8 @@ _ADDON=$(kubectl get pod -n kube-system -l component=kube-addon-manager --no-hea
 echo Addon-manager log:
 kubectl logs -n kube-system $_ADDON
 k8s_all_pods_ready 4 -n kube-system || true
+echo Addon-manager describe:
+kubectl describe pod -n kube-system $_ADDON
 echo Addon-manager log:
 kubectl logs -n kube-system $_ADDON
 k8s_all_pods_ready 4 -n kube-system

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -102,7 +102,6 @@ $_MINIKUBE start --kubernetes-version=${K8S_VERSION}  \
   ${_VM_DRIVER:-}
 # Fix the kubectl context, as it's often stale.
 $_MINIKUBE update-context
-$_MINIKUBE addons list
 echo Minikube disks:
 if [[ "${USE_MINIKUBE_DRIVER_NONE:-}" = "true" ]]; then
   # minikube does not support ssh for --vm-driver=none
@@ -113,6 +112,10 @@ fi
 
 # Wait for Kubernetes to be up and ready.
 k8s_single_node_ready
+
+echo Minikube addons:
+$_MINIKUBE addons list
+kubectl get storageclass
 
 helm init
 k8s_single_pod_ready -n kube-system -l name=tiller

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -116,6 +116,8 @@ k8s_single_node_ready
 echo Minikube addons:
 $_MINIKUBE addons list
 kubectl get storageclass
+echo Showing kube-system pods
+kubectl get -n kube-system pods
 
 helm init
 k8s_single_pod_ready -n kube-system -l name=tiller

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -120,8 +120,8 @@ kubectl get storageclass
 echo Showing kube-system pods
 kubectl get -n kube-system pods
 
-kubectl logs -n kube-system $_ADDON
 _ADDON=$(kubectl get pod -n kube-system -l component=kube-addon-manager | cut -d/ -f2)
+kubectl logs -n kube-system $_ADDON
 k8s_all_pods_ready 4 -n kube-system || true
 kubectl logs -n kube-system $_ADDON
 k8s_all_pods_ready 4 -n kube-system

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -98,6 +98,7 @@ fi
 
 # The default bootstrapper kubeadm assumes CentOS. Travis is Debian.
 $_MINIKUBE config set bootstrapper localkube
+$_MINIKUBE config set ShowBootstrapperDeprecationNotification false || true
 $_MINIKUBE start --kubernetes-version=${K8S_VERSION}  \
   ${_VM_DRIVER:-}
 # Fix the kubectl context, as it's often stale.
@@ -118,6 +119,7 @@ $_MINIKUBE addons list
 kubectl get storageclass
 echo Showing kube-system pods
 kubectl get -n kube-system pods
+k8s_all_pods_ready 4 -n kube-system
 
 helm init
 k8s_single_pod_ready -n kube-system -l name=tiller

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -119,6 +119,11 @@ $_MINIKUBE addons list
 kubectl get storageclass
 echo Showing kube-system pods
 kubectl get -n kube-system pods
+
+kubectl log -n kube-system $_ADDON
+_ADDON=$(kubectl get pod -n kube-system -l component=kube-addon-manager | cut -d/ -f2)
+k8s_all_pods_ready 4 -n kube-system || true
+kubectl log -n kube-system $_ADDON
 k8s_all_pods_ready 4 -n kube-system
 
 helm init

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -17,8 +17,10 @@ fi
 _MY_SCRIPT="${BASH_SOURCE[0]}"
 _MY_DIR=$(cd "$(dirname "$_MY_SCRIPT")" && pwd)
 # Avoids 1.7.x because of https://github.com/kubernetes/minikube/issues/2240
-_KUBERNETES_VERSION=v1.10.0
-_MINIKUBE_VERSION=v0.25.2
+_DEFAULT_K8S_VERSION=v1.10.0
+: "${K8S_VERSION:=$_DEFAULT_K8S_VERSION}"
+_DEFAULT_MINIKUBE_VERSION=v0.26.0
+: "${MINIKUBE_VERSION:=$_DEFAULT_MINIKUBE_VERSION}"
 _HELM_VERSION=v2.8.1
 
 _UNAME_OUT=$(uname -s)
@@ -42,13 +44,13 @@ mkdir -p bin tmp
 if [[ ! -x bin/kubectl ]]; then
   echo Downloading kubectl, which is a requirement for using minikube.
   curl -Lo bin/kubectl  \
-    https://storage.googleapis.com/kubernetes-release/release/${_KUBERNETES_VERSION}/bin/${_MY_OS}/amd64/kubectl
+    https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/${_MY_OS}/amd64/kubectl
   chmod +x bin/kubectl
 fi
 if [[ ! -x bin/minikube ]]; then
   echo Downloading minikube.
   curl -Lo bin/minikube  \
-    https://storage.googleapis.com/minikube/releases/${_MINIKUBE_VERSION}/minikube-${_MY_OS}-amd64
+    https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-${_MY_OS}-amd64
   chmod +x bin/minikube
 fi
 if [[ ! -x bin/helm ]]; then
@@ -96,7 +98,7 @@ fi
 
 # The default bootstrapper kubeadm assumes CentOS. Travis is Debian.
 $_MINIKUBE config set bootstrapper localkube
-$_MINIKUBE start --kubernetes-version=${_KUBERNETES_VERSION}  \
+$_MINIKUBE start --kubernetes-version=${K8S_VERSION}  \
   ${_VM_DRIVER:-}
 # Fix the kubectl context, as it's often stale.
 $_MINIKUBE update-context

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -17,8 +17,8 @@ fi
 _MY_SCRIPT="${BASH_SOURCE[0]}"
 _MY_DIR=$(cd "$(dirname "$_MY_SCRIPT")" && pwd)
 # Avoids 1.7.x because of https://github.com/kubernetes/minikube/issues/2240
-_KUBERNETES_VERSION=v1.9.4
-_MINIKUBE_VERSION=v0.25.2
+_KUBERNETES_VERSION=v1.10.0
+_MINIKUBE_VERSION=v0.26.0
 _HELM_VERSION=v2.8.1
 
 _UNAME_OUT=$(uname -s)

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -120,10 +120,10 @@ kubectl get storageclass
 echo Showing kube-system pods
 kubectl get -n kube-system pods
 
-kubectl log -n kube-system $_ADDON
+kubectl logs -n kube-system $_ADDON
 _ADDON=$(kubectl get pod -n kube-system -l component=kube-addon-manager | cut -d/ -f2)
 k8s_all_pods_ready 4 -n kube-system || true
-kubectl log -n kube-system $_ADDON
+kubectl logs -n kube-system $_ADDON
 k8s_all_pods_ready 4 -n kube-system
 
 helm init

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -100,6 +100,7 @@ $_MINIKUBE start --kubernetes-version=${_KUBERNETES_VERSION}  \
   ${_VM_DRIVER:-}
 # Fix the kubectl context, as it's often stale.
 $_MINIKUBE update-context
+$_MINIKUBE addons list
 echo Minikube disks:
 if [[ "${USE_MINIKUBE_DRIVER_NONE:-}" = "true" ]]; then
   # minikube does not support ssh for --vm-driver=none

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -120,7 +120,7 @@ kubectl get storageclass
 echo Showing kube-system pods
 kubectl get -n kube-system pods
 
-_ADDON=$(kubectl get pod -n kube-system -l component=kube-addon-manager | cut -d/ -f2)
+_ADDON=$(kubectl get pod -n kube-system -l component=kube-addon-manager --no-headers -o name| cut -d/ -f2)
 kubectl logs -n kube-system $_ADDON
 k8s_all_pods_ready 4 -n kube-system || true
 kubectl logs -n kube-system $_ADDON

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -18,7 +18,7 @@ _MY_SCRIPT="${BASH_SOURCE[0]}"
 _MY_DIR=$(cd "$(dirname "$_MY_SCRIPT")" && pwd)
 # Avoids 1.7.x because of https://github.com/kubernetes/minikube/issues/2240
 _KUBERNETES_VERSION=v1.10.0
-_MINIKUBE_VERSION=v0.26.0
+_MINIKUBE_VERSION=v0.25.2
 _HELM_VERSION=v2.8.1
 
 _UNAME_OUT=$(uname -s)


### PR DESCRIPTION
Closes #35. Also adds a new `krb5-server` chart for the Kerberos KDC server, currently used mainly for CI.