### PR TITLE
Fix dfs.datanode.data.dir

### DIFF
--- a/charts/hdfs-config-k8s/templates/_helpers.tpl
+++ b/charts/hdfs-config-k8s/templates/_helpers.tpl
@@ -51,12 +51,12 @@ last item does not have comma. It uses index 0 for the last item since that is
 the only special index that helm template gives us.
 */}}
 {{- define "datanode-data-dirs" -}}
-{{- range $index, $path := .Values.dataNodeHostPath -}}
+{{- range $index, $path := .Values.global.dataNodeHostPath -}}
   {{- if ne $index 0 -}}
     /hadoop/dfs/data/{{ $index }},
   {{- end -}}
 {{- end -}}
-{{- range $index, $path := .Values.dataNodeHostPath -}}
+{{- range $index, $path := .Values.global.dataNodeHostPath -}}
   {{- if eq $index 0 -}}
     /hadoop/dfs/data/{{ $index }}
   {{- end -}}

--- a/charts/hdfs-config-k8s/templates/configmap.yaml
+++ b/charts/hdfs-config-k8s/templates/configmap.yaml
@@ -192,6 +192,6 @@ data:
       </property>
       <property>
         <name>dfs.datanode.data.dir</name>
-        <value>{{ join "," .Values.global.dataNodeHostPath }}</value>
+        <value>{{ template "datanode-data-dirs" . }}</value>
       </property>
     </configuration>


### PR DESCRIPTION
`dfs.datanode.data.dir` should point to mountpoint `/hadoop/dfs/data/{{ $index }}`  instead of `dataNodeHostPath`
vars in `datanode-data-dirs` template should be taken from global values