### PR TITLE
rm double & conflicting declaration of apiVersion in client deployment

### DIFF
--- a/charts/hdfs-client-k8s/templates/client-deployment.yaml
+++ b/charts/hdfs-client-k8s/templates/client-deployment.yaml
@@ -1,4 +1,3 @@
-apiVersion: apps/v1
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:


### PR DESCRIPTION
apiVersion has been declared twice in the client deployment. In line
with the minimum requirement of k8s v1.6, remove apps/v1. With v1.14, it
has been communicated extensions/v1beta1 deployments will no longer be
served in v1.16, so with that release, the prerequisites of README.md
or the deployment will need to be adapted.